### PR TITLE
Remove highlight from heading level 2 that says Duis Aute

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,7 +20,7 @@
         </a>
       </li>
     </ul>
-    <h2 class="highlight point">Duis Aute</h2>
+    <h2 class="point">Duis Aute</h2>
     <p>Quis nostrud exercitation ullamco <a href="https://yahoo.com" target="_blank">laboris</a> nisi ut aliquip ex ea commodo consequat.</p>
     <img src="https://www.rd.com/wp-content/uploads/2016/01/04-dog-breeds-dalmation.jpg" width="150" alt="a Dalmatian dog">
     <audio src="https://github.com/nbktechworld/introduction-to-html/raw/abcdac58651ba724c40665c82dd55f171534115f/document-two-sections/barking.mp3" controls></audio>

--- a/src/style.css
+++ b/src/style.css
@@ -34,9 +34,6 @@
 .point {
   color: red;
 }
-.highlight {
-  background-color: yellow;
-}
 
 #paragraph1 {
   color: rgb(0, 0, 0);


### PR DESCRIPTION
Remove class `highlight` that was applying a yellow background color to the heading level 2 that read `Duis Aute`.

![image](https://github.com/nbktechworld/full-stack-web-dev/assets/13649002/51f66a27-630d-4b37-b33a-280c1467b8d0)

