### PR TITLE
Dont run deploy on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   deploy:
+    if: github.repository == 'nbktechworld/full-stack-web-dev'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Forked repositories were trying to deploy, but they don't have credentials. With this, prevent forks from running the deploy workflow. Only the original repository will run it.