### PR TITLE
Add-Breadcrumb-to-Sign-up-Page

### DIFF
--- a/src/signup.css
+++ b/src/signup.css
@@ -43,21 +43,17 @@ form input[type='submit'] {
   border: 1px solid #0d6efd;
 }
 
-/*BreadCrumb CSS*/
 .breadcrumb > ul {
   display: flex;
   padding: 15px;
   list-style: none;
   background-color: #eee;
 }
-
-/* Add a slash symbol (/) before/behind each list item */
 .breadcrumb li+li:before {
   padding: 8px;
   color: black;
   content: "/\00a0";
 }
-
 .breadcrumb li a:hover {
   color: #01447e;
   text-decoration: underline;

--- a/src/signup.css
+++ b/src/signup.css
@@ -43,17 +43,21 @@ form input[type='submit'] {
   border: 1px solid #0d6efd;
 }
 
+/*BreadCrumb CSS*/
 .breadcrumb > ul {
   display: flex;
   padding: 15px;
   list-style: none;
   background-color: #eee;
 }
+
+/* Add a slash symbol (/) before/behind each list item */
 .breadcrumb li+li:before {
   padding: 8px;
   color: black;
   content: "/\00a0";
 }
+
 .breadcrumb li a:hover {
   color: #01447e;
   text-decoration: underline;

--- a/src/signup.css
+++ b/src/signup.css
@@ -42,3 +42,23 @@ form input[type='submit'] {
   width: 100%;
   border: 1px solid #0d6efd;
 }
+
+/*BreadCrumb CSS*/
+.breadcrumb > ul {
+  display: flex;
+  padding: 15px;
+  list-style: none;
+  background-color: #eee;
+}
+
+/* Add a slash symbol (/) before/behind each list item */
+.breadcrumb li+li:before {
+  padding: 8px;
+  color: black;
+  content: "/\00a0";
+}
+
+.breadcrumb li a:hover {
+  color: #01447e;
+  text-decoration: underline;
+}

--- a/src/signup.html
+++ b/src/signup.html
@@ -8,6 +8,15 @@
     <link rel="stylesheet" href="signup.css">
   </head>
   <body>
+
+    <!--breadcrumbs-->
+    <nav aria-label="breadcrumb" class="breadcrumb">
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><span aria-current="Sign-up Form">Sign-up</span></li>
+      </ul>
+    </nav>
+
     <form action="https://jsonplaceholder.typicode.com/users" method="POST" id="sign-up-form">
       <div class="form-group">
         <label for="sign-up-form-name">Name</label>

--- a/src/signup.html
+++ b/src/signup.html
@@ -8,15 +8,12 @@
     <link rel="stylesheet" href="signup.css">
   </head>
   <body>
-
-    <!--breadcrumbs-->
     <nav aria-label="breadcrumb" class="breadcrumb">
       <ul>
         <li><a href="index.html">Home</a></li>
         <li><span aria-current="Sign-up Form">Sign-up</span></li>
       </ul>
     </nav>
-
     <form action="https://jsonplaceholder.typicode.com/users" method="POST" id="sign-up-form">
       <div class="form-group">
         <label for="sign-up-form-name">Name</label>


### PR DESCRIPTION
Resolve #27: I made modifications on two files (signup.html & signup.css). 

- Within the signup.html document, I enclosed the breadcrumb unordered list within navigation HTML tags to add semantic meaning, used the aria-label attribute to ensure it is compatible with accessibility devices, and added a breadcrumb class to the navigation tags to style it with CSS. The home list item includes an anchor tag with a href attribute that links the index.html page for users to go back. 

- Within the signup.css document, I used the class selector to change the unordered list from vertical to horizontal using the display attribute, removed the bullet points using the list-style attribute, and changed the color to separate the breadcrumb nav from the sign-up form. I targeted the space between list items to include padding and forward slashing using "/\00a0". 

![image](https://github.com/nbktechworld/full-stack-web-dev/assets/114943957/1db16ebb-3bd8-4f1b-85db-7f34b0952323)

