### PR TITLE
increased biography textarea height by 3 rows in signup form

### DIFF
--- a/src/signup.html
+++ b/src/signup.html
@@ -45,7 +45,7 @@
           <!-- <textarea></textarea> -->
           <div class="form-group">
             <label for="sign-up-form-bio">Write About Yourself</label>
-            <textarea name="biography" id="sign-up-form-bio"></textarea>
+            <textarea name="biography" id="sign-up-form-bio" rows="3"></textarea>
           </div>
           <div class="form-group">
             <div>


### PR DESCRIPTION
Resolve #31

Increased the textarea row height by 3 using the "rows" attribute on the "biography" named textarea tag on the signup.html page. 

![image](https://github.com/nbktechworld/full-stack-web-dev/assets/114943957/e82f3670-3479-4257-8f80-301efae5b6ee)


